### PR TITLE
Update graph.py

### DIFF
--- a/mafiasi/pks/graph.py
+++ b/mafiasi/pks/graph.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 import os
-from binascii import hexlify
 from cgi import escape as escape_html
 import xml.etree.ElementTree as ET
 

--- a/mafiasi/pks/graph.py
+++ b/mafiasi/pks/graph.py
@@ -223,8 +223,8 @@ def _get_color(signature_stats, keyid):
     return red, green, blue
 
 def _hex_color(red, green, blue):
-    color = ''.join(chr(int(round(x * 255))) for x in (red, green, blue))
-    return '#' + hexlify(color)
+    # red, green and blue are colors from [0, 1]
+    return '#' + ''.join(map(lambda x: format(int(round(x*255)), 'x'), (red, green, blue)))
 
 def _annotate_svg(filename):
     ET.register_namespace('', 'http://www.w3.org/2000/svg')


### PR DESCRIPTION
python2/3 fix: hexlify is not able to take strings as arguments

> \>>> hexlify('123')
> TypeError: a bytes-like object is required, not 'str'

this will fix that and it is a nicer solution imho (maybe we can skip the round. I think it doesn't matter)