### PR TITLE
Gprot: new table layout

### DIFF
--- a/mafiasi/gprot/static/css/gprot.css
+++ b/mafiasi/gprot/static/css/gprot.css
@@ -1,6 +1,6 @@
 #search-items {
-    border:1px solid #ccc;
-    margin-bottom:10px;
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
     background-color: #F5F5F5;
     border-radius: 4px;
     box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.05) inset;
@@ -16,5 +16,52 @@
 }
 
 .gprot-actions {
+    white-space: nowrap;
+}
+
+.table {
+    display: table;
+}
+
+.table-row {
+    display: table-row;
+}
+
+.cell {
+    display: table-cell;
+    padding: 10px;
+    border-top: 1px solid #ddd;
+}
+
+.table-header {
+    display: table-header-group;
+}
+
+.row-group {
+    display: table-row-group;
+}
+
+.table-header .cell {
+    font-weight: bold;
+}
+
+a.table-row {
+    color: unset;
+    text-decoration: none;
+}
+
+a.table-row:hover {
+    background-color: #e0e0e0 !important;
+}
+
+.table-striped .table-header {
+    background-color: #f9f9f9;
+}
+
+.table-striped .table-row:nth-of-type(2n) {
+    background-color: #f9f9f9;
+}
+
+.table-labels {
     white-space: nowrap;
 }

--- a/mafiasi/gprot/templates/gprot/_gprot_list.html
+++ b/mafiasi/gprot/templates/gprot/_gprot_list.html
@@ -33,9 +33,9 @@
                         </div>
                         <div class="cell" style="text-align: center">
                             {% if gprot.is_pdf %}
-                                <img src="{% static "admin/img/icon-yes.svg" %}"/>
+                            <span class="glyphicon glyphicon-ok" style="color: #5cb85c;" />
                             {% else %}
-                                <img src="{% static "admin/img/icon-no.svg" %}"/>
+                            <span class="glyphicon glyphicon-remove" style="color: #d9534f;" />
                             {% endif %}
                         </div>
                     </a>

--- a/mafiasi/gprot/templates/gprot/_gprot_list.html
+++ b/mafiasi/gprot/templates/gprot/_gprot_list.html
@@ -1,0 +1,44 @@
+{% load i18n %}
+{% load static %}
+{% load gprot_extras %}
+
+<div class="table table-striped">
+            <div class="table-header">
+                <div class="cell">{% trans "Course" %}</div>
+                <div class="cell">{% trans "Exam date" %}</div>
+                <div class="cell">{% trans "Examiners" %}</div>
+                {% if has_status %}
+                <div class="cell">{% trans "Status" %}</div>
+                {% endif %}
+                <div class="cell">{% trans "Labels" %}</div>
+                <div class="cell" style="text-align: center">{% trans "PDF?" %}</div>
+            </div>
+            <div class="row-group">
+                {% for gprot in gprots %}
+                    <a class="table-row" href="{% url 'gprot_view' gprot.pk %}">
+                        <div class="cell">{{ gprot.course.get_full_name }}</div>
+                        <div class="cell">{{ gprot.exam_date|date:"SHORT_DATE_FORMAT" }}</div>
+                        <div class="cell">{{ gprot.examiners|format_examiners }}</div>
+                        {% if has_status %}
+                        <div class="cell">
+                            {% if gprot.published %}
+                                <span class="label label-success">{% trans "published" %}</span>
+                            {% else %}
+                                <span class="label label-danger">{% trans "unpublished" %}</span>
+                            {% endif %}
+                        </div>
+                        {% endif %}
+                        <div class="cell table-labels">
+                            {% include "gprot/_labels.html" %}
+                        </div>
+                        <div class="cell" style="text-align: center">
+                            {% if gprot.is_pdf %}
+                                <img src="{% static "admin/img/icon-yes.svg" %}"/>
+                            {% else %}
+                                <img src="{% static "admin/img/icon-no.svg" %}"/>
+                            {% endif %}
+                        </div>
+                    </a>
+                {% endfor %}
+            </div>
+        </div>

--- a/mafiasi/gprot/templates/gprot/index.html
+++ b/mafiasi/gprot/templates/gprot/index.html
@@ -34,42 +34,9 @@
 
 {% if gprots %}
 <hr/>
-<table class="table table-striped">
-    <tr>
-        <th>{% trans "Course" %}</th>
-        <th>{% trans "Department" %}</th>
-        <th>{% trans "Exam date" %}</th>
-        <th>{% trans "Examiners" %}</th>
-        <th>{%  trans "Labels" %}</th>
-        <th style="text-align: center">{% trans "PDF?" %}</th>
-        <th>{% trans "Actions" %}</th>
-    </tr>
-{% for gprot in gprots %}
-    <tr>
-        <td>{{ gprot.course.get_full_name }}</td>
-        <td>
-            {% if gprot.course.department %}
-            {{ gprot.course.department }}
-            {% endif %}
-        </td>
-        <td>{{ gprot.exam_date|date:"SHORT_DATE_FORMAT" }}</td>
-        <td>{{ gprot.examiners|format_examiners }}</td>
-        <td>
-            {% include "gprot/_labels.html" %}
-        </td>
-        <td style="text-align: center">
-            {% if gprot.is_pdf %}
-            <img src="{% static "admin/img/icon-yes.svg" %}"/>
-            {% else %}
-            <img src="{% static "admin/img/icon-no.svg" %}"/>
-            {%  endif %}
-        </td>
-        <td class="gprot-actions">
-            {% include 'gprot/_action_list.html' %}
-        </td>
-    </tr>
-{% endfor %}
-</table>
+    {% with has_status=False %}
+        {% include "gprot/_gprot_list.html" %}
+    {% endwith %}
 {% elif is_query %}
 <hr/>
 <div class="alert alert-warning">

--- a/mafiasi/gprot/templates/gprot/list_own.html
+++ b/mafiasi/gprot/templates/gprot/list_own.html
@@ -6,55 +6,20 @@
 {% block wtitle %}{% block ptitle %}{% trans "List own memory minutes" %}{% endblock %}{% endblock %}
 
 {% block submenu %}
-{% include "gprot/menu.html" with tab='own' %}
+    {% include "gprot/menu.html" with tab='own' %}
 {% endblock %}
 
 {% block content %}
-{% if gprots %}
-<table class="table table-striped">
-    <tr>
-        <th>{% trans "Course" %}</th>
-        <th>{% trans "Exam date" %}</th>
-        <th>{% trans "Examiners" %}</th>
-        <th>{% trans "Status" %}</th>
-        <th>{% trans "Labels" %}</th>
-        <th style="text-align: center">{% trans "PDF?" %}</th>
-        <th>{% trans "Actions" %}</th>
-    </tr>
-{% for gprot in gprots %}
-    <tr>
-        <td>{{ gprot.course.get_full_name }}</td>
-        <td>{{ gprot.exam_date|date:"SHORT_DATE_FORMAT" }}</td>
-        <td>{{ gprot.examiners|format_examiners }}</td>
-        <td>
-        {% if gprot.published %}
-        <span class="label label-success">{% trans "published" %}</span>
-        {% else %}
-        <span class="label label-danger">{% trans "unpublished" %}</span>
-        {% endif %}
-        </td>
-        <td>
-            {% include "gprot/_labels.html" %}
-        </td>
-        <td style="text-align: center">
-            {% if gprot.is_pdf %}
-            <img src="{% static "admin/img/icon-yes.svg" %}"/>
-            {% else %}
-            <img src="{% static "admin/img/icon-no.svg" %}"/>
-            {%  endif %}
-        </td>
-        <td class="gprot-actions">
-            {% include 'gprot/_action_list.html' %}
-        </td>
-    </tr>
-{% endfor %}
-</table>
-{% else %}
-<p>{% trans "You have no memory minutes we know of! :-(" %}</p>
-{% endif %}
-<p><a class="btn btn-primary" href="{% url 'gprot_create' %}">{% trans "Create new" %}</a></p>
+    {% if gprots %}
+        {% with has_status=True %}
+        {% include "gprot/_gprot_list.html" %}
+        {% endwith %}
+    {% else %}
+        <p>{% trans "You have no memory minutes we know of! :-(" %}</p>
+    {% endif %}
+    <p><a class="btn btn-primary" href="{% url 'gprot_create' %}">{% trans "Create new" %}</a></p>
 {% endblock %}
 
 {% block css %}
-<link rel="stylesheet" type="text/css" href="{% static 'css/gprot.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/gprot.css' %}"/>
 {% endblock %}

--- a/mafiasi/gprot/templates/gprot/view.html
+++ b/mafiasi/gprot/templates/gprot/view.html
@@ -24,6 +24,11 @@ Memory minutes: {{ course_name }}
     </a>
     {% if not gprot.published %}
     {% if not gprot.is_pdf or gprot.content_pdf %}
+        <a class="btn btn-danger" href="{% url 'gprot_delete' gprot.pk %}"
+   title="{% trans 'Delete' %}">
+    <span class="glyphicon glyphicon-trash"></span>
+        {% trans "Delete" %}
+    </a>
     <a class=" btn btn-success" href="{% url 'gprot_publish' gprot.pk %}">
         <span class="glyphicon glyphicon-globe"></span>
         {% trans 'Publish' %}</a>


### PR DESCRIPTION
This will make it possible to click on a row to get to the gprot page instead of having to use the small button. Also the action buttons have all been removed from the table, because they are already shown on the individual pages (a button to delete the gprot before it's published was also added there). Departments were removed from the table, because it was convenient and they are quite useless.