### PR TITLE
make port 11371 serviceport instead of nodeport

### DIFF
--- a/k8s/services.yml
+++ b/k8s/services.yml
@@ -2,21 +2,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  name: "mafiasi-dashboard-hkp"
-spec:
-  type: "NodePort"
-  selector:
-    app: "mafiasi-dashboard"
-  ports:
-    - name: "hkp"
-      port: 11371
-      nodePort: 11371
-      targetPort: "hkp"
-
----
-apiVersion: "v1"
-kind: "Service"
-metadata:
   name: "mafiasi-dashboard"
 spec:
   type: "ClusterIP"
@@ -26,3 +11,6 @@ spec:
     - name: "http"
       port: 80
       targetPort: "http"
+    - name: "hkp"
+      port: 11371
+      targetPort: "hkp"


### PR DESCRIPTION
This makes port 11371 a port of the service instead of a nodeport so that

- multiple instances (e.g. for staging) of the dashboard can run in parallel
- the port can be managed by ingress-nginx