### PR TITLE
Fix mumble and jabber fingerprints in dashboard

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -32,6 +32,20 @@ spec:
         - name: "gnupg"
           hostPath:
             path: "/srv/dashboard/storage/.gnupg"
+        - name: "mumble-cert"
+          readOnly: true
+          secret:
+            secretName: "mumble.mafiasi.de-cert"
+            items:
+              - key: "tls.crt"
+                path: "tls.crt"
+        - name: "jabber-cert"
+          readOnly: true
+          secret:
+            secretName: "jabber.mafiasi.de-cert"
+            items:
+              - key: "tls.crt"
+                path: "tls.crt"
 
       containers:
         # dashboard backend
@@ -48,4 +62,8 @@ spec:
               mountPath: "/app/media"
             - name: "gnupg"
               mountPath: "/app/.gnupg"
+            - name: "mumble-cert"
+              mountPath: "/app/mumble-cert"
+            - name: "jabber-cert"
+              mountPath: "/app/jabber-cert"
           imagePullPolicy: "Always"

--- a/mafiasi/jabber/views.py
+++ b/mafiasi/jabber/views.py
@@ -13,12 +13,9 @@ def index(request):
     jabber_user = get_or_create_account(request.user)
     user_display_name = request.user.get_ldapuser().display_name
 
-    with open(settings.JABBER_CERT_FINGERPRINT_FILE) as file:
-        cert_fingerprint = file.read()
-
     return TemplateResponse(request, 'jabber/index.html', {
         'jabber_user': jabber_user,
         'user_display_name': user_display_name,
         'jabber_domain': settings.JABBER_DOMAIN,
-        'cert_fingerprint': cert_fingerprint
+        'cert_fingerprint': settings.JABBER_CERT_FINGERPRINT,
     })

--- a/mafiasi/mumble/views.py
+++ b/mafiasi/mumble/views.py
@@ -7,10 +7,8 @@ def index(request):
         'label': _('Student association'),
     }
     config.update(settings.MUMBLE_SERVER)
-    with open(settings.MUMBLE_CERT_FINGERPRINT_FILE) as file:
-        cert_fingerprint = file.read()
 
     return TemplateResponse(request, 'mumble/index.html', {
         'config': config,
-        'cert_fingerprint': cert_fingerprint,
+        'cert_fingerprint': settings.MUMBLE_CERT_FINGERPRINT,
     })

--- a/mafiasi/settings.py.example
+++ b/mafiasi/settings.py.example
@@ -103,13 +103,22 @@ REGISTER_DOMAINS = [u'informatik.uni-hamburg.de', u'physnet.uni-hamburg.de']
 REGISTER_DOMAIN_MAPPING = {
     u'physnet.uni-hamburg.de': 'physnet',
 }
-JABBER_DOMAIN = u'jabber.mafiasi.de'
-JABBER_CERT_FINGERPRINT_FILE = os.path.join('/', 'app', 'config', 'jabber_cert_fingerprint')
-MUMBLE_CERT_FINGERPRINT_FILE = os.path.join('/', 'app', 'config', 'mumble_cert_fingerprint')
+JABBER_DOMAIN = 'jabber.mafiasi.de'
+JABBER_CERT_FILE = '/app/jabber-cert/tls.crt'
+if os.path.isfile(JABBER_CERT_FILE):
+    JABBER_CERT_FINGERPRINT = subprocess.check_output(['openssl', 'x509', '-in', JABBER_CERT_FILE, '-noout', '-fingerprint']).decode().strip()
+else:
+    JABBER_CERT_FINGERPRINT = ''
+
 MUMBLE_SERVER = {
-    'address': u'mumble.mafiasi.de',
+    'address': 'mumble.mafiasi.de',
     'port': 64738,
 }
+MUMBLE_CERT_FILE = '/app/mumble-cert/tls.crt'
+if os.path.isfile(MUMBLE_CERT_FILE):
+    MUMBLE_CERT_FINGERPRINT = subprocess.check_output(['openssl', 'x509', '-in', MUMBLE_CERT_FILE, '-noout', '-fingerprint']).decode().strip()
+else:
+    MUMBLE_CERT_FINGERPRINT = ''
 
 DATABASE_ROUTERS = ['mafiasi.jabber.dbrouter.JabberRouter', 'ldapdb.router.Router']
 


### PR DESCRIPTION
With kubernetes, we can mount the certificates in the dashboard container and then calculate the fingerprint with openssl.