### PR TITLE
Changed 'fullscreen-button' name to represent actual function

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -321,8 +321,8 @@ msgid "Pad: %(pad_name)s"
 msgstr "Pad: %(pad_name)s"
 
 #: mafiasi/etherpad/templates/etherpad/pad.html:18
-msgid "Show this pad in fullscreen mode"
-msgstr "Zeige dieses Pad im Vollbildmodus"
+msgid "Hide navigation bars"
+msgstr "Navigationsleisten verstecken"
 
 #: mafiasi/fb18/apps.py:10
 msgid "FB18"

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -317,8 +317,8 @@ msgid "Pad: %(pad_name)s"
 msgstr "Pad: %(pad_name)s"
 
 #: mafiasi/etherpad/templates/etherpad/pad.html:18
-msgid "Show this pad in fullscreen mode"
-msgstr "Show this pad in fullscreen mode"
+msgid "Hide navigation bars"
+msgstr "Hide navigation bars"
 
 #: mafiasi/fb18/apps.py:10
 msgid "FB18"

--- a/locale/fr_FR/LC_MESSAGES/django.po
+++ b/locale/fr_FR/LC_MESSAGES/django.po
@@ -326,8 +326,8 @@ msgid "Pad: %(pad_name)s"
 msgstr "PAD: %(pad_name)s"
 
 #: mafiasi/etherpad/templates/etherpad/pad.html:18
-msgid "Show this pad in fullscreen mode"
-msgstr "Montrer ce pad en mode plein écran"
+msgid "Hide navigation bars"
+msgstr "Masquer les barres de navigation"
 
 #: mafiasi/fb18/apps.py:10
 msgid "FB18"

--- a/mafiasi/etherpad/templates/etherpad/pad.html
+++ b/mafiasi/etherpad/templates/etherpad/pad.html
@@ -15,7 +15,7 @@
         style="border:0;border-top:1px solid #000; border-bottom:1px solid #000;"></iframe>
 </div>
 {% if not fullscreen %}
-<p id="fullscreen-link" style="text-align:center;"><a href="?fullscreen">{% trans "Show this pad in fullscreen mode" %}</a></p>
+<p id="fullscreen-link" style="text-align:center;"><a href="?fullscreen">{% trans "Hide navigation bars" %}</a></p>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Closes #57 

Changed button title "Show this pad in fullscreen mode" to "Hide navigation bars" to represent the actual functionality of the button.