### PR TITLE
Remove EMAIL_FIELD and password reset

### DIFF
--- a/mafiasi/base/models.py
+++ b/mafiasi/base/models.py
@@ -44,9 +44,6 @@ class Mafiasi(AbstractUser):
     real_email = models.EmailField(unique=True, null=True)
     new_password = None
 
-    # USED in contrib.auth to determine the mail address for thinks like password reset
-    EMAIL_FIELD = "real_email"
-
     REQUIRED_FIELDS = ["email", "real_email"]
 
     @property

--- a/mafiasi/registration/urls.py
+++ b/mafiasi/registration/urls.py
@@ -9,7 +9,6 @@ urlpatterns = [
     path("change_email/<token>", change_email, name="registration_change_email"),
     path("request_successful", request_successful, name="registration_request_successful"),
     path("account", account_settings, name="registration_account"),
-    path("password_reset", password_reset, name="registration_password_reset"),
 ]
 
 if settings.REGISTER_ENABLED:

--- a/mafiasi/registration/views.py
+++ b/mafiasi/registration/views.py
@@ -317,7 +317,7 @@ def _finish_account_request(request, info):
 
 def _send_email_exists(request, username):
     email = Mafiasi.objects.get(username=username).real_email
-    password_reset_url = request.build_absolute_uri(reverse("registration_password_reset"))
+    password_reset_url = settings.KEYCLOAK_ACCOUNT_CONSOLE_URL
     email_content = render_to_string(
         "registration/email_exists.txt",
         {
@@ -359,20 +359,3 @@ def _send_mail_or_error_page(subject, content, address, request, email_shown):
             "email": email_shown,
         },
     )
-
-
-def password_reset(request):
-    password_reset_url = settings.PASSWORD_RESET_URL
-    if password_reset_url is None:
-        password_reset_url = (
-            settings.OPENID_ISSUER
-            + "/login-actions/reset-credentials?"
-            + urlencode(
-                {
-                    "response_type": "code",
-                    "client_id": settings.OPENID_CLIENT_ID,
-                    "redirect_uri": request.build_absolute_uri(reverse(settings.LOGIN_URL)),
-                }
-            )
-        )
-    return redirect(password_reset_url)


### PR DESCRIPTION
The `EMAIL_FIELD` is used by our openid library to map email addresses, overwriting existing email addresses. We could implement a custom user mapper but we can also simple remove the `EMAIL_FIELD` because it is no longer required for password reset which is done via keycloak. (Previously, it was the field used to match the address a user enters into the password reset form with their account.)