### PR TITLE
use str instead of slug for /nextcloud/set_quota username variable

### DIFF
--- a/mafiasi/nextcloud/urls.py
+++ b/mafiasi/nextcloud/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from .views import set_quota
 
 urlpatterns = [
-    path("set_quota/<slug:username>", set_quota, name="nextcloud_set_quota"),
+    path("set_quota/<str:username>", set_quota, name="nextcloud_set_quota"),
 ]


### PR DESCRIPTION
This fixes a bug where we weren't able to set quotas for accounts that have a `.` character in their name